### PR TITLE
CI/CD: Add automated Python packaging

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,7 @@ on:
       - 'sycl_source/*'
       - '.github/workflows/linux.yml'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-linux:
@@ -95,3 +96,12 @@ jobs:
         name: BilateralGPU-Linux
         path: install/lib/*.so
 
+  build-wheel:
+    name: Package Wheel (Linux)
+    needs: build-linux
+    uses: ./.github/workflows/wheel.yml
+    with:
+      os: ubuntu-24.04
+      artifact_name: BilateralGPU-Linux
+      artifact_path: install/lib
+      build_sdist: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
       run: cmake --install build_sycl --prefix install
 
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: BilateralGPU-Linux
         path: install/lib/*.so

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,83 @@
+name: Publish release & PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'which tag to upload to'
+        default: ''
+
+jobs:
+  tag:
+    name: Create Tag/Release
+    runs-on: ubuntu-latest
+    if: github.event.inputs.tag != ''
+    outputs:
+      tag: ${{ github.event.inputs.tag }}
+    permissions:
+      contents: write
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          generate_release_notes: true
+          prerelease: true
+
+  build-linux:
+    needs: tag
+    uses: ./.github/workflows/linux.yml
+
+  build-windows:
+    needs: tag
+    uses: ./.github/workflows/windows.yml
+    with:
+      tag: ${{ github.event.inputs.tag }}
+
+  publish:
+    name: Publish to PyPI & GitHub Release
+    needs: [tag, build-linux, build-windows]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.tag != ''
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vapoursynth-bilateralgpu
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - name: Download wheels
+      uses: actions/download-artifact@v8
+      with:
+        pattern: wheel-*
+        path: dist
+        merge-multiple: true
+
+    - name: Download sdist
+      uses: actions/download-artifact@v8
+      with:
+        name: sdist
+        path: dist
+        merge-multiple: true
+      continue-on-error: true
+
+    - name: Download release assets
+      uses: actions/download-artifact@v8
+      with:
+        name: release-assets
+        path: release-assets
+
+    - name: Upload to GitHub Release
+      uses: softprops/action-gh-release@v3
+      with:
+        tag_name: ${{ github.event.inputs.tag }}
+        files: |
+          dist/*
+          release-assets/*
+        fail_on_unmatched_files: false
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,73 @@
+name: Build Wheel Helper
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      artifact_path:
+        required: true
+        type: string
+      build_sdist:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build-wheel:
+    name: Build wheel on ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v8.0.0
+
+    - name: Download binaries
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_path }}
+
+    - name: Build wheel
+      run: uv build --wheel
+
+    - name: Repair wheel (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        uvx --with patchelf auditwheel repair --strip --exclude libcuda.so.1 dist/*.whl -w dist/repaired
+        rm dist/*.whl
+        mv dist/repaired/*.whl dist/
+
+    - name: Upload wheel
+      uses: actions/upload-artifact@v7
+      with:
+        name: wheel-${{ inputs.os }}
+        path: dist/*.whl
+
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    if: inputs.build_sdist
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v8.0.0
+
+    - name: Build sdist
+      run: uv build --sdist
+
+    - name: Upload sdist
+      uses: actions/upload-artifact@v7
+      with:
+        name: sdist
+        path: dist/*.tar.gz

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,9 +9,11 @@ on:
       - 'sycl_source/*'
       - '.github/workflows/windows.yml'
   workflow_dispatch:
+  workflow_call:
     inputs:
       tag:
-        description: 'which tag to upload to'
+        type: string
+        required: false
         default: ''
 
 jobs:
@@ -117,26 +119,33 @@ jobs:
         path: install/bin/*.dll
 
     - name: Compress artifact for release
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+      if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
       run: |
         cd install
 
-        mkdir VapourSynth-BilateralGPU-${{ github.event.inputs.tag }}
-        echo f | xcopy bin\bilateralgpu.dll VapourSynth-BilateralGPU-${{ github.event.inputs.tag }}\BilateralGPU.dll /f
-        7z a -t7z -mx=9 ../VapourSynth-BilateralGPU-${{ github.event.inputs.tag }}.7z VapourSynth-BilateralGPU-${{ github.event.inputs.tag }}
+        mkdir VapourSynth-BilateralGPU-${{ inputs.tag }}
+        echo f | xcopy bin\bilateralgpu.dll VapourSynth-BilateralGPU-${{ inputs.tag }}\BilateralGPU.dll /f
+        7z a -t7z -mx=9 ../VapourSynth-BilateralGPU-${{ inputs.tag }}.7z VapourSynth-BilateralGPU-${{ inputs.tag }}
 
-        mkdir VapourSynth-BilateralGPU_RTC-${{ github.event.inputs.tag }}
-        echo f | xcopy bin\bilateralgpu_rtc.dll VapourSynth-BilateralGPU_RTC-${{ github.event.inputs.tag }}\BilateralGPU_RTC.dll /f
-        7z a -t7z -mx=9 ../VapourSynth-BilateralGPU_RTC-${{ github.event.inputs.tag }}.7z VapourSynth-BilateralGPU_RTC-${{ github.event.inputs.tag }}
+        mkdir VapourSynth-BilateralGPU_RTC-${{ inputs.tag }}
+        echo f | xcopy bin\bilateralgpu_rtc.dll VapourSynth-BilateralGPU_RTC-${{ inputs.tag }}\BilateralGPU_RTC.dll /f
+        7z a -t7z -mx=9 ../VapourSynth-BilateralGPU_RTC-${{ inputs.tag }}.7z VapourSynth-BilateralGPU_RTC-${{ inputs.tag }}
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+    - name: Upload release assets
+      if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+      uses: actions/upload-artifact@v7
       with:
-        tag_name: ${{ github.event.inputs.tag }}
-        files: |
-          VapourSynth-BilateralGPU-${{ github.event.inputs.tag }}.7z
-          VapourSynth-BilateralGPU_RTC-${{ github.event.inputs.tag }}.7z
-        fail_on_unmatched_files: true
-        generate_release_notes: false
-        prerelease: true
+        name: release-assets
+        path: |
+          VapourSynth-BilateralGPU-${{ inputs.tag }}.7z
+          VapourSynth-BilateralGPU_RTC-${{ inputs.tag }}.7z
+
+  build-wheel:
+    name: Package Wheel (Windows)
+    needs: build-windows
+    uses: ./.github/workflows/wheel.yml
+    with:
+      os: windows-2022
+      artifact_name: BilateralGPU-Windows
+      artifact_path: install/bin
+      build_sdist: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
 
     - name: Cache CUDA
       id: cache-cuda
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA
         key: ${{ runner.os }}-cuda-13.0.1
@@ -76,7 +76,7 @@ jobs:
     - name: Cache SYCL
       id: cache-sycl
       if: false
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: C:\Program Files (x86)\Intel\oneAPI
         key: ${{ runner.os }}-dpcpp-2023.2.2
@@ -113,7 +113,7 @@ jobs:
       run: cmake --install build_sycl --prefix install
 
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: BilateralGPU-Windows
         path: install/bin/*.dll

--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,11 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+.venv/
+dist/
+uv.lock

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,24 @@
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from packaging import tags
+
+
+class CustomHook(BuildHookInterface[Any]):
+    if sys.platform == "win32":
+        source_dir = Path("install/bin")
+    else:
+        source_dir = Path("install/lib")
+
+    target_dir = Path("vapoursynth/plugins/bilateralgpu")
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        build_data["pure_python"] = False
+        build_data["tag"] = f"py3-none-{next(tags.platform_tags())}"
+        self.target_dir.mkdir(parents=True, exist_ok=True)
+        for file_path in self.source_dir.glob("*"):
+            if file_path.is_file() and file_path.suffix in [".dll", ".so"]:
+                shutil.copy2(file_path, self.target_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling>=1.29.0", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vapoursynth-bilateralgpu"
+dynamic = ["version"]
+description = "Bilateral filter for VapourSynth"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.12"
+authors = [{ name = "WolframRhodium" }]
+maintainers = [
+    { name = "WolframRhodium" },
+    { name = "Vardë", email = "ichunjo.le.terrible@gmail.com" },
+]
+dependencies = ["vapoursynth>=74"]
+
+[dependency-groups]
+dev = ["hatchling>=1.27.0", "packaging"]
+
+[project.urls]
+"Source Code" = "https://github.com/WolframRhodium/VapourSynth-BilateralGPU"
+"Bug Tracker" = "https://github.com/WolframRhodium/VapourSynth-BilateralGPU/issues"
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = '^r(?P<version>.*)$'
+
+[tool.hatch.build.targets.sdist]
+include = ["rtc_source", "source", "sycl_source", "config.h.in", "CMakeLists.txt"]
+
+[tool.hatch.build.targets.wheel]
+include = ["vapoursynth/plugins"]
+artifacts = [
+    "vapoursynth/plugins/**/*.so",
+    "vapoursynth/plugins/**/*.dll",
+]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"


### PR DESCRIPTION
This PR implements a Python packaging and automated release pipeline.

The `publish.yml` coordinates everything:
- Tagging
- Building (binary & wheels via the new `wheel.yml` workflow file)
- Publishing to Github releases and PyPI

This is now the workflow file to trigger when making a new release. The usage is exactly the same as before.

You will need to create an environment `pypi` in the repo Settings -> Environments -> New environment. This way, it'll be automatically uploaded.

Tested on [testpypi](https://test.pypi.org/project/vapoursynth-bilateralgpu/67/).
A [Github release](https://github.com/Varde-s-Forks/VapourSynth-BilateralGPU/releases) is also correctly made at the same time.

Some notes:
- While I was at it, I updated some Github Actions.
- The Source Distribution (sdist) isn't uploaded on PyPI since you can't build from it automatically. Adding this feature would need more changes to the build system or repo structure.
- I added a stripping step of the Linux binary for the wheel to slightly reduce the size of it.
